### PR TITLE
Refactor InputStream.read

### DIFF
--- a/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
+++ b/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
@@ -165,6 +165,7 @@ public class DaosInputStream extends FSInputStream {
   @Override
   public synchronized int read(byte[] buf, int off, int len)
           throws IOException {
+    int actualLen = 0;
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosInputStream : read from daos , contentLength = " + this.fileLen + " ;  currentPos = " +
               getPos() + "; filePos = " + this.nextReadPos);
@@ -186,35 +187,30 @@ public class DaosInputStream extends FSInputStream {
     // check buffer overlay
     long start = lastFilePos;
     long end = lastFilePos + buffer.limit();
-    if (nextReadPos >= start && nextReadPos < end) { // some requested data in buffer
+    // Copy requested data from internal buffer to result array
+    if (nextReadPos >= start && nextReadPos < end) {
       buffer.position((int) (nextReadPos - start));
-      long remaining = end - nextReadPos;
-      if (remaining >= len) {// all requested data in buffer
-        buffer.get(buf, off, len);
-        nextReadPos += len;
-        return len;
-      }
-      // part of data in buffer
-      buffer.get(buf, off, (int) remaining);
-      nextReadPos += remaining;
-      off += remaining;
-      // read more from file
-      long moreLen = readFromDaos(buf, off, (int) (len - remaining));
-      long actualLen = remaining + moreLen;
-      return (int) actualLen;
+      int remaining = (int) (end - nextReadPos);
+
+      // Want to read len bytes, and there is remaining bytes left in buffer, pick the smaller one
+      actualLen = Math.min(remaining, len);
+      buffer.get(buf, off, actualLen);
+      nextReadPos += actualLen;
+      off += actualLen;
+      len -= actualLen;
     }
-    // data not in buffer
-    long actualLen = readFromDaos(buf, off, len);
+    // Read data from DAOS
+    actualLen += readFromDaos(buf, off, len);
     if (actualLen == 0) {
-      return -1; // reach end of file
+      actualLen = -1;
     }
-    return (int) actualLen;
+    return actualLen;
   }
 
-  private long readFromDaos(byte[] buf, int off, int len) throws IOException {
-    long numBytes = 0;
+  private int readFromDaos(byte[] buf, int off, int len) throws IOException {
+    int numBytes = 0;
     while (len > 0 && (nextReadPos < fileLen)) {
-      long actualLen = readFromDaos(len);
+      int actualLen = readFromDaos(len);
       if (actualLen == 0) {
         break;
       }
@@ -232,7 +228,7 @@ public class DaosInputStream extends FSInputStream {
   /**
    * Read data from DAOS and put into cache buffer.
    */
-  private long readFromDaos(long length) throws IOException {
+  private int readFromDaos(int length) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosInputStream : read from daos ,filePos = {}", this.nextReadPos);
     }
@@ -248,7 +244,7 @@ public class DaosInputStream extends FSInputStream {
       currentTime = System.currentTimeMillis();
     }
 
-    long actualLen = this.daosFile.read(this.buffer, 0, this.nextReadPos, length);
+    int actualLen = (int)this.daosFile.read(this.buffer, 0, this.nextReadPos, length);
     lastFilePos = nextReadPos;
     buffer.limit((int) actualLen);
     stats.incrementReadOps(1);

--- a/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
+++ b/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
@@ -187,7 +187,7 @@ public class DaosInputStream extends FSInputStream {
     // check buffer overlay
     long start = lastFilePos;
     long end = lastFilePos + buffer.limit();
-    // Copy requested data from internal buffer to result array
+    // Copy requested data from internal buffer to result array if possible
     if (nextReadPos >= start && nextReadPos < end) {
       buffer.position((int) (nextReadPos - start));
       int remaining = (int) (end - nextReadPos);
@@ -199,7 +199,7 @@ public class DaosInputStream extends FSInputStream {
       off += actualLen;
       len -= actualLen;
     }
-    // Read data from DAOS
+    // Read data from DAOS to result array
     actualLen += readFromDaos(buf, off, len);
     if (actualLen == 0) {
       actualLen = -1;

--- a/java/hadoop-daos/src/test/java/com/intel/daos/hadoop/fs/DaosInputStreamTest.java
+++ b/java/hadoop-daos/src/test/java/com/intel/daos/hadoop/fs/DaosInputStreamTest.java
@@ -12,6 +12,7 @@ import org.mockito.stubbing.Answer;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Answers.RETURNS_SMART_NULLS;
@@ -458,6 +459,50 @@ public class DaosInputStreamTest {
         Assert.assertEquals(shouldThemEqual, (internalBuffer.get(i) == data[i]));
       }
     }
+  }
+
+  @Test
+  public void testCallingInputStreamReadMultiTimes() throws IOException {
+    DaosFile file = mock(DaosFile.class);
+    FileSystem.Statistics stats = new FileSystem.Statistics("daos:///");
+
+    byte[] data = new byte[]{19, 49, 89, 64, 20, 19, 1, 2, 3};
+    int bufferSize = data.length;
+    ByteBuffer internalBuffer = ByteBuffer.allocateDirect(bufferSize);
+    AtomicInteger timesReadFromDaos = new AtomicInteger(0);
+
+    doAnswer(
+      invocationOnMock -> {
+        ByteBuffer buffer = (ByteBuffer) invocationOnMock.getArguments()[0];
+        int times = timesReadFromDaos.incrementAndGet();
+        Assert.assertTrue("Read to internal buffer more than once!", times <= 1);
+        long bufferOffset = (long) invocationOnMock.getArguments()[1];
+        long fileOffset = (long) invocationOnMock.getArguments()[2];
+        long len = (long) invocationOnMock.getArguments()[3];
+        if (len > buffer.capacity() - bufferOffset) {
+          throw new IOException(
+            String.format("buffer (%d) has no enough space start at %d for reading %d bytes from file",
+              buffer.capacity(), bufferOffset, len));
+        }
+        long actualRead = 0;
+        for (long i = bufferOffset; i < bufferOffset + len &&
+                (i - bufferOffset + fileOffset) < data.length; i++) {
+          buffer.put((int) i, data[(int) (i - bufferOffset + fileOffset)]);
+          actualRead ++;
+        }
+        return actualRead;
+      })
+      .when(file)
+      .read(any(ByteBuffer.class), anyLong(), anyLong(), anyLong());
+    doReturn((long)data.length).when(file).length();
+
+    DaosInputStream input = new DaosInputStream(file, stats, internalBuffer, bufferSize, true);
+    int readSize = 3;
+    byte[] answer = new byte[bufferSize];
+    input.read(answer, 0, readSize);
+    input.read(answer, readSize, bufferSize-readSize);
+    byte[] expect = data;
+    Assert.assertArrayEquals(expect, answer);
   }
 
 }


### PR DESCRIPTION
This PR refactors the read func by:
- Reducing the branches to only 2: 1)Copy data in buffer to result array2)Read data from DAOS to result array
- Reducing function exits to be more readable
- Although the underlevel DAOS supports reading a `long len`, but Hadoop level read has `int len`, and the internal buffer length is within the limit of Integer, so change some types to `Int` 

Passed DaosInputStreamTest