### PR TITLE
More logs and no min check

### DIFF
--- a/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/Constants.java
+++ b/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/Constants.java
@@ -61,13 +61,11 @@ public final class Constants {
   public static final String DAOS_READ_BUFFER_SIZE = "fs.daos.read.buffer.size";
   public static final int DEFAULT_DAOS_READ_BUFFER_SIZE = 8 * 1024 * 1024;
   public static final int MAXIMUM_DAOS_READ_BUFFER_SIZE = Integer.MAX_VALUE;
-  public static final int MINIMUM_DAOS_READ_BUFFER_SIZE = 1 * 1024 * 1024;
 
   // the minimum and default preload size, maximum size
   public static final String DAOS_PRELOAD_SIZE = "fs.daos.preload.size";
   public static final int DEFAULT_DAOS_PRELOAD_SIZE = 4 * 1024 * 1024;
   public static final int MAXIMUM_DAOS_PRELOAD_SIZE = Integer.MAX_VALUE;
-  public static final int MINIMUM_DAOS_PRELOAD_SIZE = 1 * 1024 * 1024;
 
   // the minimum and default preload size, maximum size
   public static final String DAOS_BUFFERED_READ_ENABLED = "fs.daos.io.bufferedReadEnabled";

--- a/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosFileSystem.java
+++ b/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosFileSystem.java
@@ -177,16 +177,12 @@ public class DaosFileSystem extends FileSystem {
       this.bufferedReadEnabled = conf.getBoolean(Constants.DAOS_BUFFERED_READ_ENABLED,
               Constants.DEFAULT_BUFFERED_READ_ENABLED);
 
-      checkSizeMin(readBufferSize, Constants.MINIMUM_DAOS_READ_BUFFER_SIZE,
-              "internal read buffer size should be no less than ");
       checkSizeMin(writeBufferSize, Constants.MINIMUM_DAOS_WRITE_BUFFER_SIZE,
               "internal write buffer size should be no less than ");
       checkSizeMin(blockSize, Constants.MINIMUM_DAOS_BLOCK_SIZE,
               "block size should be no less than ");
       checkSizeMin(chunkSize, Constants.MINIMUM_DAOS_CHUNK_SIZE,
               "daos chunk size should be no less than ");
-      checkSizeMin(preLoadBufferSize, Constants.MINIMUM_DAOS_PRELOAD_SIZE,
-              "preload buffer size should be no less than ");
 
       checkSizeMax(readBufferSize, Constants.MAXIMUM_DAOS_READ_BUFFER_SIZE,
               "internal read buffer size should not be greater than ");
@@ -263,7 +259,8 @@ public class DaosFileSystem extends FileSystem {
           Path f,
           final int bufferSize) throws IOException {
     if (LOG.isDebugEnabled()) {
-      LOG.debug("DaosFileSystem open :  path = " + f.toUri().getPath() + " ; buffer size = " + bufferSize);
+      LOG.debug("DaosFileSystem open :  path = " + f.toUri().getPath() + " ; buffer size = " + readBufferSize
+        + "; preload size = " + preLoadBufferSize);
     }
 
     DaosFile file = daos.getFile(f.toUri().getPath());

--- a/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
+++ b/src/client/java/hadoop-daos/src/main/java/com/intel/daos/hadoop/fs/DaosInputStream.java
@@ -216,6 +216,7 @@ public class DaosInputStream extends FSInputStream {
   @Override
   public synchronized int read(byte[] buf, int off, int len)
           throws IOException {
+    long startTime = System.currentTimeMillis();
     int actualLen = 0;
     if (LOG.isDebugEnabled()) {
       LOG.debug("DaosInputStream : read from daos , contentLength = " + this.fileLen + " ;  currentPos = " +
@@ -252,6 +253,10 @@ public class DaosInputStream extends FSInputStream {
     }
     // Read data from DAOS to result array
     actualLen += readFromDaos(buf, off, len);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("DaosInputStream: read function spending time is :  " +
+          (System.currentTimeMillis() - startTime) + " ; read data size : " + actualLen);
+    }
     // -1 : reach EOF
     return actualLen == 0 ? -1 : actualLen;
   }


### PR DESCRIPTION
1. More clear logs for profiling purpose.
2. As @zjf2012 as I have communicated, as an API, we should constrain the configuration's bound(min & max) as less as possible. Because it's hard for us to predict the upper-level users' varied needs. So I eliminated some lower bound check.